### PR TITLE
http-server-external

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 - `--server URL`: Overwrites base url to the api
 - `--report-file newReportFile`: Overwrites the report file name from the apitest.yml config with "newReportFile"
 - `--report-format junit`: Overwrites the report format from the apitest.yml config with "junit"
+- `--http-server-replace-url URL`: Overwrites test server url with provided one. If host and/or port are to be specified, it must contain a protocol or '//' to use the original one. It can specify a full or partial path and it will be prepended to the original one
 
 ### Examples
 
@@ -102,6 +103,24 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 ```bash
 ./apitest --single apitests/test1/manifest.json --log-console-enable false
 ```
+
+- Run all tests in the directory **apitests** with **http server url replacement** for its host (localhost in this case) and port
+
+```bash
+./apitest -d apitests --http-server-replace-url //:8989
+```
+
+- Run all tests in the directory **apitests** with **http server url replacement** for prepending path to the original ones
+```bash
+./apitest -d apitests --http-server-replace-url /my/prefix
+```
+
+- Run all tests in the directory **apitests** with **http server url replacement** for protocol, host, port and prepending path to the original ones.
+
+```bash
+./apitest -d apitests --http-server-replace-url https://my.fancy.host:8989/my/place
+```
+
 
 # Manifest
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 - `--server URL`: Overwrites base url to the api
 - `--report-file newReportFile`: Overwrites the report file name from the apitest.yml config with "newReportFile"
 - `--report-format junit`: Overwrites the report format from the apitest.yml config with "junit"
-- `--replace-host URL`: Overwrites test server host with provided one
+- `--replace-host [host][:port]`: Overwrites test server host with provided one in template function "replace_host"
 
 ### Examples
 
@@ -104,7 +104,7 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 ./apitest --single apitests/test1/manifest.json --log-console-enable false
 ```
 
-- Run all tests in the directory **apitests** with **http server url replacement** for host
+- Run all tests in the directory **apitests** with **http server host replacement** for those templates using **replace_host** template function
 ```bash
 ./apitest -d apitests --replace-host my.fancy.host:8989
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 - `--server URL`: Overwrites base url to the api
 - `--report-file newReportFile`: Overwrites the report file name from the apitest.yml config with "newReportFile"
 - `--report-format junit`: Overwrites the report format from the apitest.yml config with "junit"
-- `--http-server-replace-url URL`: Overwrites test server url with provided one. If host and/or port are to be specified, it must contain a protocol or '//' to use the original one. It can specify a full or partial path and it will be prepended to the original one
+- `--replace-host URL`: Overwrites test server host with provided one
 
 ### Examples
 
@@ -104,21 +104,9 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 ./apitest --single apitests/test1/manifest.json --log-console-enable false
 ```
 
-- Run all tests in the directory **apitests** with **http server url replacement** for its host (localhost in this case) and port
-
+- Run all tests in the directory **apitests** with **http server url replacement** for host
 ```bash
-./apitest -d apitests --http-server-replace-url //:8989
-```
-
-- Run all tests in the directory **apitests** with **http server url replacement** for prepending path to the original ones
-```bash
-./apitest -d apitests --http-server-replace-url /my/prefix
-```
-
-- Run all tests in the directory **apitests** with **http server url replacement** for protocol, host, port and prepending path to the original ones.
-
-```bash
-./apitest -d apitests --http-server-replace-url https://my.fancy.host:8989/my/place
+./apitest -d apitests --replace-host my.fancy.host:8989
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also set the log verbosity per single testcase. The greater verbosity wi
 - `--server URL`: Overwrites base url to the api
 - `--report-file newReportFile`: Overwrites the report file name from the apitest.yml config with "newReportFile"
 - `--report-format junit`: Overwrites the report format from the apitest.yml config with "junit"
-- `--replace-host [host][:port]`: Overwrites test server host with provided one in template function "replace_host"
+- `--replace-host [host][:port]`: Overwrites built-in server host in template function "replace_host"
 
 ### Examples
 
@@ -1542,6 +1542,12 @@ Example how to range over 100 objects
     ]
 }
 ```
+
+## replace_host [url]
+
+**replace_host** replaces the host and port in the given `url` with the actual address of the built-in HTTP server (see below). This address, taken from the `manifest.json` can be overwritten with the command line parameter `--replace-host`.
+
+As an example, the URL _http://localhost/myimage.jpg_ would be changed into _http://localhost:8788/myimage.jpg_ following the example below.
 
 # HTTP Server
 

--- a/api_testsuite.go
+++ b/api_testsuite.go
@@ -126,6 +126,11 @@ type TestContainer struct {
 func (ats *Suite) parseAndRunTest(v interface{}, manifestDir, testFilePath string, k int, runParallel bool, r *report.ReportElement) bool {
 	//Init variables
 	loader := template.NewLoader(ats.datastore)
+	if externalHTTPServer != "" {
+		loader.HTTPServer = externalHTTPServer
+	} else if ats.httpServer.Addr != "" {
+		loader.HTTPServer = "//"+ats.HttpServer.Addr
+	}
 
 	isParallelPathSpec := false
 	switch t := v.(type) {
@@ -266,6 +271,11 @@ func (ats *Suite) loadManifest() ([]byte, error) {
 	var res []byte
 	logrus.Tracef("Loading manifest: %s", ats.manifestPath)
 	loader := template.NewLoader(ats.datastore)
+	if externalHTTPServer != "" {
+		loader.HTTPServer = externalHTTPServer
+	} else if ats.HttpServer != nil && ats.HttpServer.Addr != "" {
+		loader.HTTPServer = "//"+ats.HttpServer.Addr
+	}
 	manifestFile, err := filesystem.Fs.Open(ats.manifestPath)
 	if err != nil {
 		return res, fmt.Errorf("error opening manifestPath (%s): %s", ats.manifestPath, err)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	reportFormat, reportFile, serverURL                                     string
+	reportFormat, reportFile, serverURL, externalHTTPServer                                     string
 	logNetwork, logDatastore, logVerbose, logTimeStamp, logCurl, stopOnFail bool
 	rootDirectorys, singleTests                                             []string
 	limitRequest, limitResponse                                             uint
@@ -28,6 +28,10 @@ func init() {
 	testCMD.PersistentFlags().StringVar(
 		&serverURL, "server", "",
 		"URL of the Server. Overwrites server URL in yml config.")
+
+	testCMD.PersistentFlags().StringVar(
+		&externalHTTPServer, "http-server-external", "",
+		"Address of the external HTTP Server. Overwrites HTTP server addresses in test manifests.")
 
 	testCMD.PersistentFlags().StringSliceVarP(
 		&rootDirectorys, "directory", "d", []string{"."},

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	reportFormat, reportFile, serverURL, httpServerReplaceHost               string
+	reportFormat, reportFile, serverURL, httpServerReplaceHost              string
 	logNetwork, logDatastore, logVerbose, logTimeStamp, logCurl, stopOnFail bool
 	rootDirectorys, singleTests                                             []string
 	limitRequest, limitResponse                                             uint
@@ -31,7 +31,7 @@ func init() {
 
 	testCMD.PersistentFlags().StringVar(
 		&httpServerReplaceHost, "replace-host", "",
-		"Address of the HTTP Server replacement host. Overwrites HTTP server URLS in test manifests.")
+		"HTTP Server replacement host to be used in replace_host template function.")
 
 	testCMD.PersistentFlags().StringSliceVarP(
 		&rootDirectorys, "directory", "d", []string{"."},

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	reportFormat, reportFile, serverURL, externalHTTPServer                                     string
+	reportFormat, reportFile, serverURL, httpServerReplaceURL               string
 	logNetwork, logDatastore, logVerbose, logTimeStamp, logCurl, stopOnFail bool
 	rootDirectorys, singleTests                                             []string
 	limitRequest, limitResponse                                             uint
@@ -30,8 +30,8 @@ func init() {
 		"URL of the Server. Overwrites server URL in yml config.")
 
 	testCMD.PersistentFlags().StringVar(
-		&externalHTTPServer, "http-server-external", "",
-		"Address of the external HTTP Server. Overwrites HTTP server addresses in test manifests.")
+		&httpServerReplaceURL, "http-server-replace-url", "",
+		"Address of the HTTP Server replacement URL. Overwrites HTTP server URLS in test manifests.")
 
 	testCMD.PersistentFlags().StringSliceVarP(
 		&rootDirectorys, "directory", "d", []string{"."},

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	reportFormat, reportFile, serverURL, httpServerReplaceURL               string
+	reportFormat, reportFile, serverURL, httpServerReplaceHost               string
 	logNetwork, logDatastore, logVerbose, logTimeStamp, logCurl, stopOnFail bool
 	rootDirectorys, singleTests                                             []string
 	limitRequest, limitResponse                                             uint
@@ -30,8 +30,8 @@ func init() {
 		"URL of the Server. Overwrites server URL in yml config.")
 
 	testCMD.PersistentFlags().StringVar(
-		&httpServerReplaceURL, "http-server-replace-url", "",
-		"Address of the HTTP Server replacement URL. Overwrites HTTP server URLS in test manifests.")
+		&httpServerReplaceHost, "replace-host", "",
+		"Address of the HTTP Server replacement host. Overwrites HTTP server URLS in test manifests.")
 
 	testCMD.PersistentFlags().StringSliceVarP(
 		&rootDirectorys, "directory", "d", []string{"."},

--- a/pkg/lib/template/template_loader.go
+++ b/pkg/lib/template/template_loader.go
@@ -68,7 +68,7 @@ func newTemplateParams(params []interface{}) (interface{}, error) {
 
 type Loader struct {
 	datastore *datastore.Datastore
-	HTTPServerURL *url.URL
+	HTTPServerHost string
 }
 
 func NewLoader(datastore *datastore.Datastore) Loader {
@@ -283,9 +283,9 @@ func (loader *Loader) Render(
 		"match": func(regex, text string) (bool, error) {
 			return regexp.Match(regex, []byte(text))
 		},
-		"replace_http_server_url": func(srcURL string) (string, error) {
+		"replace_host": func(srcURL string) (string, error) {
 			// If no override provided, return original one
-			if loader.HTTPServerURL == nil {
+			if loader.HTTPServerHost == "" {
 				return srcURL, nil
 			}
 			// Parse source URL or fail
@@ -293,27 +293,7 @@ func (loader *Loader) Render(
 			if err != nil {
 				return "", err
 			}
-			// Go thru all provided parts and replace/add them
-			if loader.HTTPServerURL.Scheme != "" {
-				parsedURL.Scheme = loader.HTTPServerURL.Scheme
-			}
-			hostName := loader.HTTPServerURL.Hostname()
-			port := loader.HTTPServerURL.Port()
-			if hostName == "" {
-				if port != "" {
-					hostName = "localhost"
-				} else {
-					hostName = parsedURL.Hostname()
-				}
-			}
-			parsedURL.Host = hostName
-			if port != "" {
-				parsedURL.Host += ":"+port
-			}
-			path := loader.HTTPServerURL.Path
-			if path != "" {
-				parsedURL.Path = path + parsedURL.Path
-			}
+			parsedURL.Host = loader.HTTPServerHost
 			return parsedURL.String(), nil
 		},
 	}


### PR DESCRIPTION
- Added new command argument http-server-external as string
- Passing to the remplate loader such command argument or the manifest set server address
- Created template function to replace url parts with those of external http server argument or manifest address