### PR TITLE
new template function "server_url", ticket #57618

### DIFF
--- a/README.md
+++ b/README.md
@@ -1553,6 +1553,10 @@ Example how to range over 100 objects
 
 As an example, the URL _http://localhost/myimage.jpg_ would be changed into _http://localhost:8788/myimage.jpg_ following the example below.
 
+## server_url
+
+**server_url** returns (renders) the tests configured server url (api server), which can be globally provided in the yaml config file or directly by the command line parameter `--server`.
+
 # HTTP Server
 
 The apitest tool includes an HTTP Server. It can be used to serve files from the local disk temporarily. The HTTP Server can run in test mode. In this mode, the apitest tool does not run any tests, but starts the HTTP Server in the foreground, until CTRL-C in pressed.

--- a/api_testsuite.go
+++ b/api_testsuite.go
@@ -196,6 +196,12 @@ func (ats *Suite) parseAndRunTest(v interface{}, manifestDir, testFilePath strin
 	loader := template.NewLoader(ats.datastore)
 
 	loader.HTTPServerHost = ats.HTTPServerHost
+	serverURL, err := getURLWithoutAuth(ats.Config.ServerURL)
+	if err != nil {
+		logrus.Error(fmt.Errorf("can not load server url into test (%s): %s", testFilePath, err))
+		return false
+	}
+	loader.ServerURL = serverURL
 
 	isParallelPathSpec := false
 	switch t := v.(type) {
@@ -337,6 +343,11 @@ func (ats *Suite) loadManifest() ([]byte, error) {
 	logrus.Tracef("Loading manifest: %s", ats.manifestPath)
 	loader := template.NewLoader(ats.datastore)
 	loader.HTTPServerHost = ats.HTTPServerHost
+	serverURL, err := getURLWithoutAuth(ats.Config.ServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("can not load server url into manifest (%s): %s", ats.manifestPath, err)
+	}
+	loader.ServerURL = serverURL
 	manifestFile, err := filesystem.Fs.Open(ats.manifestPath)
 	if err != nil {
 		return res, fmt.Errorf("error opening manifestPath (%s): %s", ats.manifestPath, err)
@@ -374,4 +385,14 @@ func testGoRoutine(k, ki int, v json.RawMessage, ats *Suite, testFilePath, manif
 	if success {
 		<-waitCh
 	}
+}
+
+// getURLWithoutAuth helper
+func getURLWithoutAuth(srcURL string) (string, error) {
+	parsedURL, err  := url.Parse(srcURL)
+	if err != nil {
+		return "", err
+	}
+	parsedURL.User = nil
+	return parsedURL.String(), nil
 }

--- a/pkg/lib/template/template_loader.go
+++ b/pkg/lib/template/template_loader.go
@@ -67,8 +67,9 @@ func newTemplateParams(params []interface{}) (interface{}, error) {
 }
 
 type Loader struct {
-	datastore *datastore.Datastore
+	datastore      *datastore.Datastore
 	HTTPServerHost string
+	ServerURL      string
 }
 
 func NewLoader(datastore *datastore.Datastore) Loader {
@@ -298,6 +299,9 @@ func (loader *Loader) Render(
 			}
 			parsedURL.Host = loader.HTTPServerHost
 			return parsedURL.String(), nil
+		},
+		"server_url": func() string {
+			return loader.ServerURL
 		},
 	}
 	tmpl, err := template.New("tmpl").Funcs(funcMap).Parse(string(tmplBytes))


### PR DESCRIPTION
- Added server url field to template loader
- Added template loader function for retrieving server url
- Added logic in api testsuite to parse, strip auth and store configured server url into loader
- Added helper function to strip a url string from user and password basic auth