### PR TITLE
Fix control in array

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	go test ./...
 
 apitest:
-	./apitest -d test/
+	./apitest --stop-on-fail -d test/
 
 gox:
 	go get github.com/mitchellh/gox

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ Manifest is loaded as **template**, so you can use variables, Go **range** and *
         "@continue_response_processing.json"
     ],
 
-    // If set to true, the test case will consider its failure as a success, useful for testing the test suite
-    "expect_fail": false
+    // If set to true, the test case will consider its failure as a success, and the other way around
+    "reverse_test_result": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,10 @@ Manifest is loaded as **template**, so you can use variables, Go **range** and *
     "collect_response": [
         "@continue_response_pending.json",
         "@continue_response_processing.json"
-    ]
+    ],
+
+    // If set to true, the test case will consider its failure as a success, useful for testing the test suite
+    "expect_fail": false
 }
 ```
 

--- a/api_testcase.go
+++ b/api_testcase.go
@@ -52,6 +52,7 @@ type Case struct {
 	standardHeaderFromStore map[string]string
 
 	ServerURL string `json:"server_url"`
+	ExpectToFail bool `json:"expect_fail"`
 }
 
 func (testCase Case) runAPITestCase(parentReportElem *report.ReportElement) bool {

--- a/api_testcase.go
+++ b/api_testcase.go
@@ -52,7 +52,7 @@ type Case struct {
 	standardHeaderFromStore map[string]string
 
 	ServerURL string `json:"server_url"`
-	ExpectToFail bool `json:"expect_fail"`
+	ReverseTestResult bool `json:"reverse_test_result"`
 }
 
 func (testCase Case) runAPITestCase(parentReportElem *report.ReportElement) bool {
@@ -99,8 +99,10 @@ func (testCase Case) runAPITestCase(parentReportElem *report.ReportElement) bool
 		success = false
 	}
 
-	// XOR for when we want it to fail
-	success = success != testCase.ExpectToFail
+	// Reverse if needed
+	if testCase.ReverseTestResult {
+		success = !success
+	}
 
 	if !success {
 		logrus.WithFields(logrus.Fields{"elapsed": elapsed.Seconds()}).Warnf("     [%2d] failure", testCase.index)
@@ -289,7 +291,7 @@ func (testCase Case) executeRequest(counter int) (compare.CompareResult, api.Req
 func (testCase Case) LogResp(response api.Response) {
 	errString := fmt.Sprintf("[RESPONSE]:\n%s\n\n", limitLines(response.ToString(), Config.Apitest.Limit.Response))
 
-	if !testCase.ExpectToFail && testCase.LogNetwork != nil && !*testCase.LogNetwork && !testCase.ContinueOnFailure {
+	if !testCase.ReverseTestResult && testCase.LogNetwork != nil && !*testCase.LogNetwork && !testCase.ContinueOnFailure {
 		testCase.ReportElem.SaveToReportLogF(errString)
 		logrus.Debug(errString)
 	}
@@ -299,7 +301,7 @@ func (testCase Case) LogResp(response api.Response) {
 func (testCase Case) LogReq(req api.Request) {
 	errString := fmt.Sprintf("[REQUEST]:\n%s\n\n", limitLines(req.ToString(logCurl), Config.Apitest.Limit.Request))
 
-	if !testCase.ExpectToFail && !testCase.ContinueOnFailure && testCase.LogNetwork != nil && *testCase.LogNetwork == false {
+	if !testCase.ReverseTestResult && !testCase.ContinueOnFailure && testCase.LogNetwork != nil && *testCase.LogNetwork == false {
 		testCase.ReportElem.SaveToReportLogF(errString)
 		logrus.Debug(errString)
 	}
@@ -400,7 +402,7 @@ func (testCase Case) run() (bool, error) {
 	}
 
 	if !responsesMatch.Equal || timedOutFlag {
-		if !testCase.ExpectToFail {
+		if !testCase.ReverseTestResult {
 			for _, v := range responsesMatch.Failures {
 				logrus.Errorf("[%s] %s", v.Key, v.Message)
 				r.SaveToReportLog(fmt.Sprintf("[%s] %s", v.Key, v.Message))

--- a/api_testsuite.go
+++ b/api_testsuite.go
@@ -331,7 +331,7 @@ func (ats *Suite) runSingleTest(tc TestContainer, r *report.ReportElement, testF
 	}
 	success := test.runAPITestCase(r)
 
-	if !success && !test.ExpectToFail && !test.ContinueOnFailure {
+	if !success && !test.ContinueOnFailure {
 		return false
 	}
 

--- a/pkg/lib/compare/comparison_functions.go
+++ b/pkg/lib/compare/comparison_functions.go
@@ -355,7 +355,27 @@ func arrayComparison(left, right util.JsonArray, noExtra, orderMaters bool, cont
 					continue
 				}
 
-				tmp, err := JsonEqual(lv, rv, control)
+				// We need to check the left interface against the right one multiple times
+				// JsonEqual modifies such interface (it deletes it afterwards)
+				// Therefore we need a copy of it for this case 
+				var (
+					err error
+					tmp CompareResult
+				)
+				switch lv.(type) {
+				case util.JsonObject:
+					jo, ok := lv.(util.JsonObject)
+					if ok {
+						lvv := util.JsonObject{}
+						for k, v := range jo {
+							lvv[k] = v
+						}
+						tmp, err = JsonEqual(lvv, rv, control)
+					}
+				default:
+					tmp, err = JsonEqual(lv, rv, control)
+				}
+
 				if err != nil {
 					return CompareResult{}, err
 				}

--- a/pkg/lib/compare/comparison_functions.go
+++ b/pkg/lib/compare/comparison_functions.go
@@ -362,16 +362,13 @@ func arrayComparison(left, right util.JsonArray, noExtra, orderMaters bool, cont
 					err error
 					tmp CompareResult
 				)
-				switch lv.(type) {
+				switch jo := lv.(type) {
 				case util.JsonObject:
-					jo, ok := lv.(util.JsonObject)
-					if ok {
-						lvv := util.JsonObject{}
-						for k, v := range jo {
-							lvv[k] = v
-						}
-						tmp, err = JsonEqual(lvv, rv, control)
+					lvv := util.JsonObject{}
+					for k, v := range jo {
+						lvv[k] = v
 					}
+					tmp, err = JsonEqual(lvv, rv, control)
 				default:
 					tmp, err = JsonEqual(lv, rv, control)
 				}

--- a/test/control/manifest.json
+++ b/test/control/manifest.json
@@ -136,7 +136,7 @@
                     }
                 }
             },
-            "expect_fail": true
+            "reverse_test_result": true
         }
     ]
 }

--- a/test/control/manifest.json
+++ b/test/control/manifest.json
@@ -72,6 +72,71 @@
                     }
                 }
             }
+        },
+        {
+            "name": "check control structures in array (should fail)",
+            "request": {
+                "server_url": "http://localhost:9999",
+                "endpoint": "bounce-json",
+                "method": "POST",
+                "body": {
+                    "_files": [
+                        {
+                            "path": "Test XML+CSV+JSON/1-2.csv"
+                        },
+                        {
+                            "path": "Test XML+CSV+JSON/1-2.json"
+                        },
+                        {
+                            "path": "files/no-1-sid-10-berlin.jpg"
+                        },
+                        {
+                            "path": "files/no-2-sid-10-mona-lisa-1.jpg"
+                        },
+                        {
+                            "path": "files/no-3-sid-9-Gustav_Klimt_016.jpg"
+                        },
+                        {
+                            "path": "files/no-4-sid-9-art-exposition-735518_1920_big_small.png"
+                        }
+                    ]
+                }
+            },
+            "response": {
+                "statuscode": 200,
+                "body": {
+                    "body": {
+                        "_files": [
+                            {
+                                "path:control": {
+                                    "match": "^.*Gustav_Klimt_016.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*art-exposition-735518_1920.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*berlin.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*mona-lisa-1.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*henk.*$"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "expect_fail": true
         }
     ]
 }

--- a/test/control/manifest.json
+++ b/test/control/manifest.json
@@ -1,0 +1,75 @@
+{
+    "http_server": {
+        "addr": ":9999",
+        "dir": "../_res",
+        "testmode": false
+    },
+    "name": "check control structures in array",
+    "tests": [
+        {
+            "name": "check control structures in array (MUST FAIL)",
+            "request": {
+                "server_url": "http://localhost:9999",
+                "endpoint": "bounce-json",
+                "method": "POST",
+                "body": {
+                    "_files": [
+                        {
+                            "path": "Test XML+CSV+JSON/1-2.csv"
+                        },
+                        {
+                            "path": "Test XML+CSV+JSON/1-2.json"
+                        },
+                        {
+                            "path": "files/no-1-sid-10-berlin.jpg"
+                        },
+                        {
+                            "path": "files/no-2-sid-10-mona-lisa-1.jpg"
+                        },
+                        {
+                            "path": "files/no-3-sid-9-Gustav_Klimt_016.jpg"
+                        },
+                        {
+                            "path": "files/no-4-sid-9-art-exposition-735518_1920_big_small.png"
+                        }
+                    ]
+                }
+            },
+            "response": {
+                "statuscode": 200,
+                "body": {
+                    "body": {
+                        "_files": [
+                            {
+                                "path:control": {
+                                    "match": "^.*Gustav_Klimt_016.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*art-exposition-735518_1920.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*berlin.*$"
+                                }
+                            },
+                            {
+                                "path:control": {
+                                    "match": "^.*mona-lisa-1.*$"
+                                }
+                            },
+                            {
+                                // XXX this control structure needs to cause a test failure: there is no path that matches "^.*henk.*$"
+                                "path:control": {
+                                    "match": "^.*henk.*$"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/test/control/manifest.json
+++ b/test/control/manifest.json
@@ -7,7 +7,7 @@
     "name": "check control structures in array",
     "tests": [
         {
-            "name": "check control structures in array (MUST FAIL)",
+            "name": "check control structures in array",
             "request": {
                 "server_url": "http://localhost:9999",
                 "endpoint": "bounce-json",
@@ -31,6 +31,9 @@
                         },
                         {
                             "path": "files/no-4-sid-9-art-exposition-735518_1920_big_small.png"
+                        },
+                        {
+                            "path": "files/so-henk-was-here_small.png"
                         }
                     ]
                 }
@@ -61,7 +64,6 @@
                                 }
                             },
                             {
-                                // XXX this control structure needs to cause a test failure: there is no path that matches "^.*henk.*$"
                                 "path:control": {
                                     "match": "^.*henk.*$"
                                 }


### PR DESCRIPTION
The JSONObject structures used to check against the response objects are altered during the checks
This seems to be needed as modifying this behaviour makes some tests fail (in fylr for example)
In the case of checking against multiple JSONArray response values, a copy for each iteration solves the problem