### PR TITLE
Static asset file server wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1595,20 +1595,20 @@ To access any static file, use the path relative to the server directory (`dir`)
 }
 ```
 
-#### Skip Content-Length header
+If there is any error (for example wrong path), a HTTP error repsonse will be returned.
+
+#### No Content-Length header
 
 For some tests, you may not want the Content-Length header to be sent alongside the asset
-In this case, add `skip-content-length=1` to the query string of the asset url:
+In this case, add `no-content-length=1` to the query string of the asset url:
 ```yaml
 {
     "request": {
-        "endpoint": "path/to/file.jpg?skip-content-length=1",
+        "endpoint": "path/to/file.jpg?no-content-length=1",
         "method": "GET"
     }
 }
 ```
-
-If there is any error (for example wrong path), a HTTP error repsonse will be returned.
 
 ### `bounce`
 

--- a/README.md
+++ b/README.md
@@ -1595,6 +1595,19 @@ To access any static file, use the path relative to the server directory (`dir`)
 }
 ```
 
+#### Skip Content-Length header
+
+For some tests, you may not want the Content-Length header to be sent alongside the asset
+In this case, add `skip-content-length=1` to the query string of the asset url:
+```yaml
+{
+    "request": {
+        "endpoint": "path/to/file.jpg?skip-content-length=1",
+        "method": "GET"
+    }
+}
+```
+
 If there is any error (for example wrong path), a HTTP error repsonse will be returned.
 
 ### `bounce`

--- a/http_server.go
+++ b/http_server.go
@@ -28,7 +28,7 @@ func (ats *Suite) StartHttpServer() {
 	} else {
 		ats.httpServerDir = filepath.Clean(ats.manifestDir + "/" + ats.HttpServer.Dir)
 	}
-	mux.Handle("/", http.FileServer(http.Dir(ats.httpServerDir)))
+	mux.Handle("/", customStaticHandler(http.FileServer(http.Dir(ats.httpServerDir))))
 
 	// bounce json response
 	mux.HandleFunc("/bounce-json", bounceJSON)
@@ -58,6 +58,22 @@ func (ats *Suite) StartHttpServer() {
 		run()
 	} else {
 		go run()
+	}
+}
+
+// customStaticHandler can perform some operations before passing into final handler
+func customStaticHandler(h http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		qs := r.URL.Query()
+		// We try not to include Content-Length header here
+		// As ultimately the default FileServer implementation will override all of them
+		// After diving into its code, the only way to avoid it is setting Content-Encoding header to some value
+		// In this case, 'identity', as per RFC 7231 / RFC 2616, means no compression or modification
+		skipContentLengthHeader := qs.Get("skip-content-length")
+		if skipContentLengthHeader == "1" || skipContentLengthHeader == "true" {
+			w.Header().Set("Content-Encoding", "identity")
+		} 
+		h.ServeHTTP(w, r)
 	}
 }
 

--- a/http_server.go
+++ b/http_server.go
@@ -69,8 +69,8 @@ func customStaticHandler(h http.Handler) http.HandlerFunc {
 		// As ultimately the default FileServer implementation will override all of them
 		// After diving into its code, the only way to avoid it is setting Content-Encoding header to some value
 		// In this case, 'identity', as per RFC 7231 / RFC 2616, means no compression or modification
-		skipContentLengthHeader := qs.Get("skip-content-length")
-		if skipContentLengthHeader == "1" || skipContentLengthHeader == "true" {
+		noContentLengthHeader := qs.Get("no-content-length")
+		if noContentLengthHeader == "1" || noContentLengthHeader == "true" {
 			w.Header().Set("Content-Encoding", "identity")
 		} 
 		h.ServeHTTP(w, r)


### PR DESCRIPTION
- Added wrapper handler for static serve files in order to apply some modifications to response if possible
- Added content-length skip modification to static serve files
- Documented the query string parameter in request url for static file without content-length